### PR TITLE
safety: update details of banning

### DIFF
--- a/safety/approach.html
+++ b/safety/approach.html
@@ -98,8 +98,8 @@ might respond in an effort to resolve the issue:
       and decides to talk to the offender, ask them to be more gentle,
       and let them know we're considering banning them if they don't
       shape up.  Despite the warnings, they continue injuring the
-      people around them.  Safety Team proposes to the board that we
-      ban the dancer for six months, and the board agrees.
+      people around them.  Safety Team bans the dancer for six months
+      and informs the board.
   <li><p>A dancer contacts Safety Team to report that their ex was abusive
       toward them, they would like to avoid being at dances with their
       ex, and they ask Safety Team to ban their ex.  The reporter
@@ -136,8 +136,9 @@ might respond in an effort to resolve the issue:
       a hug on someone who clearly doesn't want it.  The Safety Rep
       checks with person who just got hugged, who confirms that they
       were trying to pull out of the hug. The Safety Rep asks the
-      offender to leave immediately.  Before the next dance the board
-      meets and agrees to ban the offender.
+      offender to leave immediately and informs Safety Team.  Before
+      the next dance Safety Team meets and agrees to ban the offender,
+      informing ther board.
 </ul>
 
 <p>


### PR DESCRIPTION
As confirmed at the 2024-05-15 BIDA board meeting, Safety Team does have the authority to ban people, but must inform the board.