### PR TITLE
Show the next event twice

### DIFF
--- a/dances.js
+++ b/dances.js
@@ -1479,10 +1479,10 @@ function gen_events() {
       }
     } else {
       if (next_event.children.length == 0) {
-        next_event.appendChild(event_to_append)
-      } else {
-        events.appendChild(event_to_append);
+        next_event.appendChild(
+            event_to_append.cloneNode(/*deep=*/true));
       }
+      events.appendChild(event_to_append);
     }
   }
   


### PR DESCRIPTION
In #13 the next dance is listed only at the top, and is removed from the list of upcoming dances.  I think it would be better to list it twice, since the list of upcoming dances should have all upcoming dances.