### PR TITLE
Board layout

### DIFF
--- a/board.html
+++ b/board.html
@@ -14,143 +14,271 @@
 <h2>Current Members</h2>
 
 <i>May 2025 - Apr 2026</i>
-<p>
 
-Emma Azelborn <!-- 2022 --> (Outreach Coordinator, co-Musician Booker)
+<div id="board-list">
+  <div class="board-member">
+    <img width=320 src="media/emma.jpg" srcset="media/emma-2x.jpg 2x">
+    <div class="member-info">
+      Emma Azelborn <!-- 2022 --> (Outreach Coordinator, co-Musician Booker)
+    </div>
+  </div>
 
-<p>
-<img width=320 src="media/emma.jpg" srcset="media/emma-2x.jpg 2x">
-<p>
+  <div class="board-member">
+    <img width=320 src="media/harris.jpg" srcset="media/harris-2x.jpg 2x">
+    <div class="member-info">
+      Harris Bard Lapiroff <!-- 2019 --> (Caller Booker, Secretary, Family Dance Coordinator)
+    </div>
+  </div>
 
-Harris Bard Lapiroff <!-- 2019 --> (Caller Booker, Secretary, Family Dance Coordinator)
+  <div class="board-member">
+    <img width=320 src="media/bret.jpg">
+    <div class="member-info">
+      Bret Casey <!-- 2024 --> (co-Musician Booker, co-Intraboard Coordinator)
+    </div>
+  </div>
 
-<p>
-<img width=320 src="media/harris.jpg" srcset="media/harris-2x.jpg 2x">
-<p>
+  <div class="board-member">
+    <img width=320 src="media/veer.jpg" srcset="media/veer-2x.jpg 2x">
+    <div class="member-info">
+      Veer Dedhia <!-- 2022 --> (Treasurer)
+    </div>
+  </div>
 
-Bret Casey <!-- 2024 --> (co-Musician Booker, co-Intraboard Coordinator)
+  <div class="board-member">
+    <img width=320 src="media/cindy.jpg" srcset="media/cindy-2x.jpg 2x">
+    <div class="member-info">
+      Cindy Dill <!-- 2024 --> (co-Intraboard Coordinator, co-Volunteer Coordinator)
+    </div>
+  </div>
 
-<p>
-<img width=320 src="media/bret.jpg">
-<p>
+  <div class="board-member">
+    <img width=320 src="media/jeff.jpg" srcset="media/jeff-2x.jpg 2x">
+    <div class="member-info">
+      Jeff Kaufman <!-- 2010 --> (Website, Sound Coordination)
+    </div>
+  </div>
 
-Veer Dedhia <!-- 2022 --> (Treasurer)
+  <div class="board-member">
+    <img width=320 src="media/casey.jpg" srcset="media/casey-2x.jpg 2x">
+    <div class="member-info">
+      Casey Murray <!-- 2025 --> (co-Volunteer Coordinator, Jam coordinator)
+    </div>
+  </div>
 
-<p>
-<img width=320 src="media/veer.jpg" srcset="media/veer-2x.jpg 2x">
-<p>
+  <div class="board-member">
+    <img width=320 src="media/naomi.jpg" srcset="media/naomi-2x.jpg 2x">
+    <div class="member-info">
+      Naomi Ingber <!-- 2022 --> (Family Dances, Email Lists, Beantown Stomp, Assistant Treasurer)
+    </div>
+  </div>
 
-Cindy Dill <!-- 2024 --> (co-Intraboard Coordinator, co-Volunteer Coordinator)
-
-<p>
-<img width=320 src="media/cindy.jpg" srcset="media/cindy-2x.jpg 2x">
-<p>
-
-Jeff Kaufman <!-- 2010 --> (Website, Sound Coordination)
-
-<p>
-<img width=320 src="media/jeff.jpg" srcset="media/jeff-2x.jpg 2x">
-<p>
-
-Casey Murray <!-- 2025 --> (co-Volunteer Coordinator, Jam coordinator)
-
-<p>
-<img width=320 src="media/casey.jpg" srcset="media/casey-2x.jpg 2x">
-<p>
-
-Naomi Ingber <!-- 2022 --> (Family Dances, Email Lists, Beantown Stomp, Assistant Treasurer)
-
-<p>
-<img width=320 src="media/naomi.jpg" srcset="media/naomi-2x.jpg 2x">
-<p>
-
-Persis Thorndike <!-- 2018 --> (co-Volunteer Coordinator, Spark in the Dark)
-
-<p>
-<img width=320 src="media/persis.jpg" srcset="media/persis-2x.jpg 2x">
-<p>
+  <div class="board-member">
+    <img width=320 src="media/persis.jpg" srcset="media/persis-2x.jpg 2x">
+    <div class="member-info">
+      Persis Thorndike <!-- 2018 --> (co-Volunteer Coordinator, Spark in the Dark)
+    </div>
+  </div>
+</div>
 
 <h2>Past Members</h2>
 
-Eric McDonald (2008-2009), no photo<p>
+<div id="board-list-past">
+  <div class="board-member">
+    <div class="member-info">
+      Eric McDonald (2008-2009), no photo
+    </div>
+  </div>
 
-Dave Casserly (2008-2011)
-<p><img width=320 src='media/dave.jpg' srcset='media/dave-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/dave.jpg' srcset='media/dave-2x.jpg 2x'>
+    <div class="member-info">
+      Dave Casserly (2008-2011)
+    </div>
+  </div>
 
-Chris Weiler (2009-2011), no photo<p>
+  <div class="board-member">
+    <div class="member-info">
+      Chris Weiler (2009-2011), no photo
+    </div>
+  </div>
 
-Koren Wake (2009-2011)
-<p><img width=320 src='media/koren.jpg' srcset='media/koren-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/koren.jpg' srcset='media/koren-2x.jpg 2x'>
+    <div class="member-info">
+      Koren Wake (2009-2011)
+    </div>
+  </div>
 
-Martha Friedman (2009-2012), no photo<p>
+  <div class="board-member">
+    <div class="member-info">
+      Martha Friedman (2009-2012), no photo
+    </div>
+  </div>
 
-Daniel Friedman (2009-2015)
-<p><img width=320 src='media/daniel.jpg' srcset='media/daniel-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/daniel.jpg' srcset='media/daniel-2x.jpg 2x'>
+    <div class="member-info">
+      Daniel Friedman (2009-2015)
+    </div>
+  </div>
 
-Alex Krogh-Grabbe (2010-2012)
-<p><img width=320 src='media/alex.jpg' srcset='media/alex-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/alex.jpg' srcset='media/alex-2x.jpg 2x'>
+    <div class="member-info">
+      Alex Krogh-Grabbe (2010-2012)
+    </div>
+  </div>
 
-Sally Bown (2011-2012), no photo<p>
+  <div class="board-member">
+    <div class="member-info">
+      Sally Bown (2011-2012), no photo
+    </div>
+  </div>
 
-Andrew Stout (2011-2013)
-<p><img width=320 src='media/andrew.jpg' srcset='media/andrew-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/andrew.jpg' srcset='media/andrew-2x.jpg 2x'>
+    <div class="member-info">
+      Andrew Stout (2011-2013)
+    </div>
+  </div>
 
-Michael Bergman (2011-2014)
-<p><img width=320 src='media/mike.jpg' srcset='media/mike-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/mike.jpg' srcset='media/mike-2x.jpg 2x'>
+    <div class="member-info">
+      Michael Bergman (2011-2014)
+    </div>
+  </div>
 
-Max Newman (2012), no photo<p>
+  <div class="board-member">
+    <div class="member-info">
+      Max Newman (2012), no photo
+    </div>
+  </div>
 
-Heather Carmichael (2012), no photo<p>
+  <div class="board-member">
+    <div class="member-info">
+      Heather Carmichael (2012), no photo
+    </div>
+  </div>
 
-Ben Sachs Hamilton (2012-2013)
-<p><img width=320 src='media/ben.jpg' srcset='media/ben-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/ben.jpg' srcset='media/ben-2x.jpg 2x'>
+    <div class="member-info">
+      Ben Sachs Hamilton (2012-2013)
+    </div>
+  </div>
 
-Audrey Knuth (2013-2015)
-<p><img width=320 src='media/audrey.jpg' srcset='media/audrey-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/audrey.jpg' srcset='media/audrey-2x.jpg 2x'>
+    <div class="member-info">
+      Audrey Knuth (2013-2015)
+    </div>
+  </div>
 
-Amy Englesberg (2013-2014)
-<p><img width=320 src='media/amy.jpg' srcset='media/amy-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/amy.jpg' srcset='media/amy-2x.jpg 2x'>
+    <div class="member-info">
+      Amy Englesberg (2013-2014)
+    </div>
+  </div>
 
-Kathleen Fownes (2014)
-<p><img width=320 src='media/kathleen.jpg' srcset='media/kathleen-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/kathleen.jpg' srcset='media/kathleen-2x.jpg 2x'>
+    <div class="member-info">
+      Kathleen Fownes (2014)
+    </div>
+  </div>
 
-Sam Auciello (2014-2016)
-<p><img width=320 src='media/sam.jpg' srcset='media/sam-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/sam.jpg' srcset='media/sam-2x.jpg 2x'>
+    <div class="member-info">
+      Sam Auciello (2014-2016)
+    </div>
+  </div>
 
-Daniel Ley (2014-2016)
-<p><img width=320 src='media/dan.jpg' srcset='media/dan-2x.jpg 2x'><p>
+  <div class="board-member">
+    <img width=320 src='media/dan.jpg' srcset='media/dan-2x.jpg 2x'>
+    <div class="member-info">
+      Daniel Ley (2014-2016)
+    </div>
+  </div>
 
-Ryan McLoughlin (2016-2017), no photo<p>
+  <div class="board-member">
+    <div class="member-info">
+      Ryan McLoughlin (2016-2017), no photo
+    </div>
+  </div>
 
-Angela DeCarlis (2015-2018)
-<p><img width=320 src="media/angela.jpg" srcset="media/angela-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/angela.jpg" srcset="media/angela-2x.jpg 2x">
+    <div class="member-info">
+      Angela DeCarlis (2015-2018)
+    </div>
+  </div>
 
-Cecile Leroy (2017-2018)
-<p><img width=320 src="media/cecile.jpg" srcset="media/cecile-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/cecile.jpg" srcset="media/cecile-2x.jpg 2x">
+    <div class="member-info">
+      Cecile Leroy (2017-2018)
+    </div>
+  </div>
 
-Avalon (A.Z.) Madonna (2016-2019)
-<p><img width=320 src="media/avalon.jpg" srcset="media/avalon-2x.jpg"><p>
+  <div class="board-member">
+    <img width=320 src="media/avalon.jpg" srcset="media/avalon-2x.jpg">
+    <div class="member-info">
+      Avalon (A.Z.) Madonna (2016-2019)
+    </div>
+  </div>
 
-Julie Vallimont (2008-2020)
-<p><img width=320 src="media/julie.jpg" srcset="media/julie-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/julie.jpg" srcset="media/julie-2x.jpg 2x">
+    <div class="member-info">
+      Julie Vallimont (2008-2020)
+    </div>
+  </div>
 
-Rachel Sensenig (2017-2022)
-<p><img width=320 src="media/rachel.jpg" srcset="media/rachel-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/rachel.jpg" srcset="media/rachel-2x.jpg 2x">
+    <div class="member-info">
+      Rachel Sensenig (2017-2022)
+    </div>
+  </div>
 
-Marcus Graly (2017-2022)<p>
-<p><img width=320 src="media/marcus.jpg" srcset="media/marcus-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/marcus.jpg" srcset="media/marcus-2x.jpg 2x">
+    <div class="member-info">
+      Marcus Graly (2017-2022)
+    </div>
+  </div>
 
-Sarah Hirsch (2013-2022)<p>
-<p><img width=320 src="media/sarah.jpg" srcset="media/sarah-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/sarah.jpg" srcset="media/sarah-2x.jpg 2x">
+    <div class="member-info">
+      Sarah Hirsch (2013-2022)
+    </div>
+  </div>
 
-Ben Rechel (2022-2023)<p>
-<p><img width=320 src="media/ben-r.jpg" srcset="media/ben-r-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/ben-r.jpg" srcset="media/ben-r-2x.jpg 2x">
+    <div class="member-info">
+      Ben Rechel (2022-2023)
+    </div>
+  </div>
 
-Kelly Huang (2022-2024)<p>
-<p><img width=320 src="media/kelly.jpg" srcset="media/kelly-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/kelly.jpg" srcset="media/kelly-2x.jpg 2x">
+    <div class="member-info">
+      Kelly Huang (2022-2024)
+    </div>
+  </div>
 
-Nate Banks (2024-2025)<p>
-<img width=320 src="media/nate.jpg" srcset="media/nate-2x.jpg 2x"><p>
+  <div class="board-member">
+    <img width=320 src="media/nate.jpg" srcset="media/nate-2x.jpg 2x">
+    <div class="member-info">
+      Nate Banks (2024-2025)
+    </div>
+  </div>
+</div>
 
 </div>
 <a href="/"><div id=back-bar>&larr; main page</div></a>

--- a/board.html
+++ b/board.html
@@ -162,7 +162,7 @@
   <div class="board-member">
     <img width=320 src='media/dan.jpg' srcset='media/dan-2x.jpg 2x'>
     <div class="member-info">
-      Daniel Ley (2014-2016)
+      Daniel Raine (2014-2016)
     </div>
   </div>
 

--- a/board.html
+++ b/board.html
@@ -84,21 +84,172 @@
 
 <div id="board-list-past">
   <div class="board-member">
+    <img width=320 src="media/nate.jpg" srcset="media/nate-2x.jpg 2x">
     <div class="member-info">
-      Eric McDonald (2008-2009), no photo
+      Nate Banks (2024-2025)
     </div>
   </div>
 
   <div class="board-member">
-    <img width=320 src='media/dave.jpg' srcset='media/dave-2x.jpg 2x'>
+    <img width=320 src="media/kelly.jpg" srcset="media/kelly-2x.jpg 2x">
     <div class="member-info">
-      Dave Casserly (2008-2011)
+      Kelly Huang (2022-2024)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/ben-r.jpg" srcset="media/ben-r-2x.jpg 2x">
+    <div class="member-info">
+      Ben Rechel (2022-2023)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/sarah.jpg" srcset="media/sarah-2x.jpg 2x">
+    <div class="member-info">
+      Sarah Hirsch (2013-2022)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/marcus.jpg" srcset="media/marcus-2x.jpg 2x">
+    <div class="member-info">
+      Marcus Graly (2017-2022)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/rachel.jpg" srcset="media/rachel-2x.jpg 2x">
+    <div class="member-info">
+      Rachel Sensenig (2017-2022)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/julie.jpg" srcset="media/julie-2x.jpg 2x">
+    <div class="member-info">
+      Julie Vallimont (2008-2020)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/avalon.jpg" srcset="media/avalon-2x.jpg">
+    <div class="member-info">
+      Avalon (A.Z.) Madonna (2016-2019)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/cecile.jpg" srcset="media/cecile-2x.jpg 2x">
+    <div class="member-info">
+      Cecile Leroy (2017-2018)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src="media/angela.jpg" srcset="media/angela-2x.jpg 2x">
+    <div class="member-info">
+      Angela DeCarlis (2015-2018)
     </div>
   </div>
 
   <div class="board-member">
     <div class="member-info">
-      Chris Weiler (2009-2011), no photo
+      Ryan McLoughlin (2016-2017), no photo
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/dan.jpg' srcset='media/dan-2x.jpg 2x'>
+    <div class="member-info">
+      Daniel Ley (2014-2016)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/sam.jpg' srcset='media/sam-2x.jpg 2x'>
+    <div class="member-info">
+      Sam Auciello (2014-2016)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/kathleen.jpg' srcset='media/kathleen-2x.jpg 2x'>
+    <div class="member-info">
+      Kathleen Fownes (2014)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/amy.jpg' srcset='media/amy-2x.jpg 2x'>
+    <div class="member-info">
+      Amy Englesberg (2013-2014)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/audrey.jpg' srcset='media/audrey-2x.jpg 2x'>
+    <div class="member-info">
+      Audrey Knuth (2013-2015)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/ben.jpg' srcset='media/ben-2x.jpg 2x'>
+    <div class="member-info">
+      Ben Sachs Hamilton (2012-2013)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <div class="member-info">
+      Heather Carmichael (2012), no photo
+    </div>
+  </div>
+
+  <div class="board-member">
+    <div class="member-info">
+      Max Newman (2012), no photo
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/mike.jpg' srcset='media/mike-2x.jpg 2x'>
+    <div class="member-info">
+      Michael Bergman (2011-2014)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/andrew.jpg' srcset='media/andrew-2x.jpg 2x'>
+    <div class="member-info">
+      Andrew Stout (2011-2013)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <div class="member-info">
+      Sally Bown (2011-2012), no photo
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/alex.jpg' srcset='media/alex-2x.jpg 2x'>
+    <div class="member-info">
+      Alex Krogh-Grabbe (2010-2012)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <img width=320 src='media/daniel.jpg' srcset='media/daniel-2x.jpg 2x'>
+    <div class="member-info">
+      Daniel Friedman (2009-2015)
+    </div>
+  </div>
+
+  <div class="board-member">
+    <div class="member-info">
+      Martha Friedman (2009-2012), no photo
     </div>
   </div>
 
@@ -111,171 +262,20 @@
 
   <div class="board-member">
     <div class="member-info">
-      Martha Friedman (2009-2012), no photo
+      Chris Weiler (2009-2011), no photo
     </div>
   </div>
 
   <div class="board-member">
-    <img width=320 src='media/daniel.jpg' srcset='media/daniel-2x.jpg 2x'>
+    <img width=320 src='media/dave.jpg' srcset='media/dave-2x.jpg 2x'>
     <div class="member-info">
-      Daniel Friedman (2009-2015)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/alex.jpg' srcset='media/alex-2x.jpg 2x'>
-    <div class="member-info">
-      Alex Krogh-Grabbe (2010-2012)
+      Dave Casserly (2008-2011)
     </div>
   </div>
 
   <div class="board-member">
     <div class="member-info">
-      Sally Bown (2011-2012), no photo
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/andrew.jpg' srcset='media/andrew-2x.jpg 2x'>
-    <div class="member-info">
-      Andrew Stout (2011-2013)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/mike.jpg' srcset='media/mike-2x.jpg 2x'>
-    <div class="member-info">
-      Michael Bergman (2011-2014)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <div class="member-info">
-      Max Newman (2012), no photo
-    </div>
-  </div>
-
-  <div class="board-member">
-    <div class="member-info">
-      Heather Carmichael (2012), no photo
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/ben.jpg' srcset='media/ben-2x.jpg 2x'>
-    <div class="member-info">
-      Ben Sachs Hamilton (2012-2013)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/audrey.jpg' srcset='media/audrey-2x.jpg 2x'>
-    <div class="member-info">
-      Audrey Knuth (2013-2015)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/amy.jpg' srcset='media/amy-2x.jpg 2x'>
-    <div class="member-info">
-      Amy Englesberg (2013-2014)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/kathleen.jpg' srcset='media/kathleen-2x.jpg 2x'>
-    <div class="member-info">
-      Kathleen Fownes (2014)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/sam.jpg' srcset='media/sam-2x.jpg 2x'>
-    <div class="member-info">
-      Sam Auciello (2014-2016)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src='media/dan.jpg' srcset='media/dan-2x.jpg 2x'>
-    <div class="member-info">
-      Daniel Ley (2014-2016)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <div class="member-info">
-      Ryan McLoughlin (2016-2017), no photo
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/angela.jpg" srcset="media/angela-2x.jpg 2x">
-    <div class="member-info">
-      Angela DeCarlis (2015-2018)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/cecile.jpg" srcset="media/cecile-2x.jpg 2x">
-    <div class="member-info">
-      Cecile Leroy (2017-2018)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/avalon.jpg" srcset="media/avalon-2x.jpg">
-    <div class="member-info">
-      Avalon (A.Z.) Madonna (2016-2019)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/julie.jpg" srcset="media/julie-2x.jpg 2x">
-    <div class="member-info">
-      Julie Vallimont (2008-2020)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/rachel.jpg" srcset="media/rachel-2x.jpg 2x">
-    <div class="member-info">
-      Rachel Sensenig (2017-2022)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/marcus.jpg" srcset="media/marcus-2x.jpg 2x">
-    <div class="member-info">
-      Marcus Graly (2017-2022)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/sarah.jpg" srcset="media/sarah-2x.jpg 2x">
-    <div class="member-info">
-      Sarah Hirsch (2013-2022)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/ben-r.jpg" srcset="media/ben-r-2x.jpg 2x">
-    <div class="member-info">
-      Ben Rechel (2022-2023)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/kelly.jpg" srcset="media/kelly-2x.jpg 2x">
-    <div class="member-info">
-      Kelly Huang (2022-2024)
-    </div>
-  </div>
-
-  <div class="board-member">
-    <img width=320 src="media/nate.jpg" srcset="media/nate-2x.jpg 2x">
-    <div class="member-info">
-      Nate Banks (2024-2025)
+      Eric McDonald (2008-2009), no photo
     </div>
   </div>
 </div>

--- a/board.html
+++ b/board.html
@@ -155,7 +155,7 @@
 
   <div class="board-member">
     <div class="member-info">
-      Ryan McLoughlin (2016-2017), no photo
+      Ryan McLoughlin (2016-2017)
     </div>
   </div>
 
@@ -203,13 +203,13 @@
 
   <div class="board-member">
     <div class="member-info">
-      Heather Carmichael (2012), no photo
+      Heather Carmichael (2012)
     </div>
   </div>
 
   <div class="board-member">
     <div class="member-info">
-      Max Newman (2012), no photo
+      Max Newman (2012)
     </div>
   </div>
 
@@ -229,7 +229,7 @@
 
   <div class="board-member">
     <div class="member-info">
-      Sally Bown (2011-2012), no photo
+      Sally Bown (2011-2012)
     </div>
   </div>
 
@@ -249,7 +249,7 @@
 
   <div class="board-member">
     <div class="member-info">
-      Martha Friedman (2009-2012), no photo
+      Martha Friedman (2009-2012)
     </div>
   </div>
 
@@ -262,7 +262,7 @@
 
   <div class="board-member">
     <div class="member-info">
-      Chris Weiler (2009-2011), no photo
+      Chris Weiler (2009-2011)
     </div>
   </div>
 
@@ -275,7 +275,7 @@
 
   <div class="board-member">
     <div class="member-info">
-      Eric McDonald (2008-2009), no photo
+      Eric McDonald (2008-2009)
     </div>
   </div>
 </div>

--- a/main.css
+++ b/main.css
@@ -305,4 +305,33 @@ li {
     margin-top: -.25em;
   }
 }
+
+#board-list, #board-list-past {
+  max-width: 320px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2em;
+  padding: 1em 0;
+}
+
+.board-member {
+  background-color: rgba(165, 11, 32, .08);
+  border-radius: 0.5em;
+  padding: 1em;
+  width: 100%;
+}
+
+.board-member img {
+  width: 100%;
+  border-radius: 0.25em;
+  margin-bottom: 1em;
+  display: block;
+}
+
+.member-info {
+  padding: 0.5em;
+  line-height: 1.4;
+  text-align: center;
+}
   


### PR DESCRIPTION
- adds cards and moves the name to below the image so it looks like a typical caption
- reverses the past board member list so most recent is first
- removes the "no photo" mention because that's obvious now that there are cards

tested that it works on mobile with chrome's inspector's "mobile" toggle and it seems fine there

<img width="399" alt="image" src="https://github.com/user-attachments/assets/a5fc5a80-e79a-4343-b22e-830a00147146" />

<img width="408" alt="image" src="https://github.com/user-attachments/assets/2c9abdd7-6e01-4bfa-8b00-f19a22b89613" />
