### PR TITLE
payscale: update family dance pay

### DIFF
--- a/payscale.html
+++ b/payscale.html
@@ -19,8 +19,8 @@
 <li>Open band anchor: same as standard musicians
 <li>Open band sound: if only one person is running sound for the
     evening, extra $40
-<li>Family dance caller / musician: $30, plus an extra $45 if they're
-    not also doing the evening dance
+<li>Family dance caller / musician: $75 (regardless of whether they're
+    also doing the evening dance)
 <li>Hall manager: $15/session ($30/evening)
 </ul>
 


### PR DESCRIPTION
As discussed at 2025-08-10 board retreat, we've decided to stop paying musicians and callers less if they are also playing the evening dance.